### PR TITLE
Add 30-day Dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 30


### PR DESCRIPTION
# Problem

Dependabot update entries have no cooldown. Best practice against zero-day supply chain attacks is to have a cooldown of some kind.

# Solution

Add a 30-day default cooldown to all four Dependabot update entries. YAML parsing and `git diff --check` pass.