### PR TITLE
Set Dependabot cadence to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,24 +6,24 @@ updates:
   - package-ecosystem: "bazel"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     cooldown:
       default-days: 30
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     cooldown:
       default-days: 30


### PR DESCRIPTION
# Problem

Dependabot checks all configured ecosystems weekly, creating dependency-update activity more frequently than desired.

# Solution

Change the Dependabot schedule for Bazel, uv, GitHub Actions, and pre-commit updates from weekly to quarterly.

Validation: file-scoped pre-commit checks and git diff validation passed.